### PR TITLE
Add hostname to returned data

### DIFF
--- a/src/nagios.go
+++ b/src/nagios.go
@@ -114,8 +114,15 @@ func collectServiceCheck(sc serviceCheck, i *integration.Integration) {
 	// Run the command for the service check
 	stdout, stderr, exit := runCommand(sc.Command[0], sc.Command[1:]...)
 
+	// Set the hostname
+	serverName, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+
 	// Create a metric set
 	ms := e.NewMetricSet("NagiosServiceCheckSample",
+		metric.Attribute{Key: "serverName", Value: serverName},
 		metric.Attribute{Key: "displayName", Value: sc.Name},
 		metric.Attribute{Key: "entityName", Value: "serviceCheck:" + sc.Name},
 	)

--- a/src/nagios_test.go
+++ b/src/nagios_test.go
@@ -56,6 +56,10 @@ func Test_collectServiceCheck(t *testing.T) {
 		Command: []string{"echo", "testout"},
 		Labels:  map[string]string{"testkey": "testval"},
 	}
+	serverName, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
 
 	expectedMetrics := map[string]interface{}{
 		"serviceCheck.name":    "testname",
@@ -63,6 +67,7 @@ func Test_collectServiceCheck(t *testing.T) {
 		"serviceCheck.message": "testout\n",
 		"serviceCheck.error":   "",
 		"serviceCheck.command": "echo testout",
+		"serverName":           serverName,
 		"displayName":          "testname",
 		"entityName":           "serviceCheck:testname",
 		"event_type":           "NagiosServiceCheckSample",


### PR DESCRIPTION
#### Description of the changes

Return the hostname of the server where the Nagios check has been run, so that this can be included in NRQL Alert conditions. Without this, we cannot differentiate between servers when alerting on Nagios checks.

The `os.Hostname()` call may not be in an ideal position, it would possibly make more sense to set the `serverName` var earlier, so that it is only called once while loading the integration, however I wasn't able to make this work when setting the var in `main()` (full disclosure: I'm a golang novice).

#### PR Review Checklist
### Author

*I am unable to assign a reviewer nor a label - there are none available to me to assign in either case*

- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [x] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
