### PR TITLE
Add a 'outputTableName' argument to support custom sample names

### DIFF
--- a/src/nagios_test.go
+++ b/src/nagios_test.go
@@ -79,7 +79,7 @@ func Test_collectServiceCheck(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go collectServiceCheck(sc, i, &wg)
+	go collectServiceCheck(sc, i, &wg, "NagiosServiceCheckSample")
 	wg.Wait()
 
 	id := integration.NewIDAttribute("executing_host", serverName)
@@ -100,7 +100,7 @@ func Test_collectServiceCheck_InvalidNameError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go collectServiceCheck(sc, i, &wg)
+	go collectServiceCheck(sc, i, &wg, "NagiosServiceCheckSample")
 	wg.Wait()
 
 	e, _ := i.Entity("testname", "serviceCheck")
@@ -119,7 +119,7 @@ func Test_collectServiceCheck_NoNameError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go collectServiceCheck(sc, i, &wg)
+	go collectServiceCheck(sc, i, &wg, "NagiosServiceCheckSample")
 	wg.Wait()
 
 	e, _ := i.Entity("testname", "serviceCheck")
@@ -138,7 +138,7 @@ func Test_collectServiceCheck_InvalidCommandError(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go collectServiceCheck(sc, i, &wg)
+	go collectServiceCheck(sc, i, &wg, "NagiosServiceCheckSample")
 	wg.Wait()
 
 	e, _ := i.Entity("testname", "serviceCheck")


### PR DESCRIPTION
#### Description of the changes

All results of all service checks are being added to the "NagiosServiceCheckSample", but in most situations you want to split this up to have custom samples per service check. This way you can structure your data in New Relic Insights properly.

This code is in use in a forked version in our monitoring system and has been tested, it's been working as expected.

However on every major code change, I've to re-create a patch which creates too much hassle. This way it can be pushed into the NRI Nagios code base.

#### PR Review Checklist
### Author

- [ ] the PR should focus on a single subject. Change only relevant files to the problem you’re working on
Clean and format the code
- [ ] add unit tests for your changes and make sure all unit tests are passing
- [ ] add a risk label after carefully considering the "blast radius" of your changes
- [ ] describe the _intent_ of your changes in the description. don't just rewrite your code in prose
- [ ] assign at least one reviewer
- [ ] address the feedback 

### Reviewer

- [ ] review code for readability
- [ ] verify that high risk behavior changes are well tested
- [ ] check license for any new external dependency
- [ ] ask questions about anything that isn't clear and obvious
- [ ] approve the PR when you consider it's good to merge
