### PR TITLE
Changing entityName to hostname 

### DIFF
--- a/src/nagios.go
+++ b/src/nagios.go
@@ -163,7 +163,7 @@ func collectServiceCheck(sc serviceCheck, i *integration.Integration, wg *sync.W
 	ms := e.NewMetricSet(outputTableName,
 		metric.Attribute{Key: "serverName", Value: serverName},
 		metric.Attribute{Key: "displayName", Value: sc.Name},
-		metric.Attribute{Key: "entityName", Value: "serviceCheck:" + sc.Name},
+		metric.Attribute{Key: "entityName", Value: serverName},
 	)
 
 	// Add user-defined labels to the metric set

--- a/src/nagios_linux_test.go
+++ b/src/nagios_linux_test.go
@@ -46,7 +46,7 @@ func Test_collectServiceCheck(t *testing.T) {
 		"serviceCheck.command": "echo testout",
 		"serverName":           serverName,
 		"displayName":          "testname",
-		"entityName":           "serviceCheck:testname",
+		"entityName":           serverName,
 		"event_type":           "NagiosServiceCheckSample",
 		"testkey":              "testval",
 	}


### PR DESCRIPTION
Since entities are tied to each other on different views in NR like Navigator view, when an alert is triggered on an entity it does not associate the alert to that entity due to the way Nagios entities are named (do not see an entityId being generated anywhere in the code)