### PR TITLE
fix: upgrade go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+
+### security
+- update go to v1.25.9
 ## v2.12.0 - 2026-03-25
 
 ### 🛡️ Security notices

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/nri-nagios
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/newrelic/infra-integrations-sdk/v3 v3.9.1

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
 
   nri-nagios:
-    image: golang:1.25.8-bookworm
+    image: golang:1.25.9-bookworm
     container_name: nri_nagios
     working_dir: /code
     depends_on:


### PR DESCRIPTION
## Summary
- Update Go to v1.25.9
- Run `go mod tidy` to update dependencies
- Update CHANGELOG.md with security entry

## Test plan
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)